### PR TITLE
fix: 模型烘焙完成时清空覆雪quad偏移缓存

### DIFF
--- a/src/main/java/io/github/cpearl0/ctnhcore/client/ClientProxy.java
+++ b/src/main/java/io/github/cpearl0/ctnhcore/client/ClientProxy.java
@@ -21,6 +21,7 @@ import net.createmod.ponder.foundation.PonderIndex;
 import net.minecraft.server.packs.resources.ResourceManager;
 import net.minecraft.server.packs.resources.ResourceManagerReloadListener;
 import net.minecraftforge.client.event.EntityRenderersEvent;
+import net.minecraftforge.client.event.ModelEvent;
 import net.minecraftforge.client.event.RegisterClientReloadListenersEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
@@ -72,5 +73,10 @@ public class ClientProxy extends CommonProxy {
                 SnowOverlayQuadOffset.clearOffsetCache();
             }
         });
+    }
+
+    @SubscribeEvent
+    public void onBakingCompleted(ModelEvent.BakingCompleted event) {
+        SnowOverlayQuadOffset.clearOffsetCache();
     }
 }


### PR DESCRIPTION
在 ClientProxy 增加 ModelEvent.BakingCompleted 事件，模型烘焙完成后清空 SnowOverlayQuadOffset 的 OFFSETED_QUADS，避免 ModernFix/局部模型刷新等不触发完整资源重载的路径长期持有旧 quad。保留原有 RegisterClientReloadListenersEvent 清理。