### PR TITLE
fix: 覆雪偏移仅作用于GT机械方块并消除地面缝隙

### DIFF
--- a/src/main/java/io/github/cpearl0/ctnhcore/client/util/SnowOverlayQuadOffset.java
+++ b/src/main/java/io/github/cpearl0/ctnhcore/client/util/SnowOverlayQuadOffset.java
@@ -1,5 +1,6 @@
 package io.github.cpearl0.ctnhcore.client.util;
 
+import net.minecraft.client.renderer.FaceInfo;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.core.Direction;
 import net.minecraftforge.client.model.IQuadTransformer;
@@ -35,11 +36,14 @@ public final class SnowOverlayQuadOffset {
             return;
         }
 
-        int xNormal = direction.getStepX();
-        int yNormal = direction.getStepY();
-        int zNormal = direction.getStepZ();
+        FaceInfo faceInfo = FaceInfo.fromFacing(direction);
 
         for (int i = 0; i < 4; i++) {
+            FaceInfo.VertexInfo vertexInfo = faceInfo.getVertexInfo(i);
+            int xNormal = Direction.from3DDataValue(vertexInfo.xFace).getStepX();
+            int yNormal = Direction.from3DDataValue(vertexInfo.yFace).getStepY();
+            int zNormal = Direction.from3DDataValue(vertexInfo.zFace).getStepZ();
+
             int vertexOffset = i * IQuadTransformer.STRIDE + IQuadTransformer.POSITION;
             float x = Float.intBitsToFloat(vertices[vertexOffset]);
             float y = Float.intBitsToFloat(vertices[vertexOffset + 1]);

--- a/src/main/java/io/github/cpearl0/ctnhcore/mixin/eclipticseasons/SnowyBakedModelWrapperOffsetMixin.java
+++ b/src/main/java/io/github/cpearl0/ctnhcore/mixin/eclipticseasons/SnowyBakedModelWrapperOffsetMixin.java
@@ -2,6 +2,8 @@ package io.github.cpearl0.ctnhcore.mixin.eclipticseasons;
 
 import io.github.cpearl0.ctnhcore.client.util.SnowOverlayQuadOffset;
 
+import com.gregtechceu.gtceu.api.block.IMachineBlock;
+
 import net.minecraft.client.renderer.RenderType;
 import net.minecraft.client.renderer.block.model.BakedQuad;
 import net.minecraft.client.resources.model.BakedModel;
@@ -34,7 +36,7 @@ public abstract class SnowyBakedModelWrapperOffsetMixin extends BakedModelWrappe
     @Override
     public List<BakedQuad> getQuads(BlockState state, Direction direction, RandomSource random) {
         List<BakedQuad> quads = super.getQuads(state, direction, random);
-        if (!isReplace() && ctnhcore$tryMarkOffset(direction)) {
+        if (!isReplace() && ctnhcore$isMachine(state) && ctnhcore$tryMarkOffset(direction)) {
             SnowOverlayQuadOffset.offsetAllIfNeeded(quads);
         }
         return quads;
@@ -44,10 +46,15 @@ public abstract class SnowyBakedModelWrapperOffsetMixin extends BakedModelWrappe
     public List<BakedQuad> getQuads(BlockState state, Direction direction, RandomSource random,
                                     ModelData modelData, RenderType renderType) {
         List<BakedQuad> quads = super.getQuads(state, direction, random, modelData, renderType);
-        if (!isReplace() && ctnhcore$tryMarkOffset(direction)) {
+        if (!isReplace() && ctnhcore$isMachine(state) && ctnhcore$tryMarkOffset(direction)) {
             SnowOverlayQuadOffset.offsetAllIfNeeded(quads);
         }
         return quads;
+    }
+
+    @Unique
+    private boolean ctnhcore$isMachine(BlockState state) {
+        return state != null && state.getBlock() instanceof IMachineBlock;
     }
 
     @Unique


### PR DESCRIPTION
在无缓存覆雪修复基础上处理地面缝隙问题。

- 覆雪 quad 偏移限定为 GT 机械方块（`IMachineBlock`），普通地面不再参与偏移。
- 将整面沿自身法线平移改为按 `FaceInfo` 顶点法线外扩，保持立方体棱角连续，避免地面/雪层出现裂缝。
- 仍保留覆雪 z-fighting 修复。

验证：`:modules:CTNH-Core:spotlessApply` 与 `:modules:CTNH-Core:build` 通过。