### PR TITLE
fix(build): 使用 CurseForge gt-portal 替换缺失的本地 gtportal 依赖

### DIFF
--- a/dependencies.gradle
+++ b/dependencies.gradle
@@ -20,10 +20,10 @@ dependencies {
     jarJar("extra-mods:scg-ctnh:1.1.1")
     jarJar("extra-mods:kallfix_sub-1.0:1.0")
     jarJar("extra-mods:GregTech-Construct-3.11.2.180:3.11.2.180")
-    jarJar("extra-mods:gtportal-ctnh-1.1.7:1.1.7")
+    jarJar("curse.maven:gt-portal-1459620:7884803")
 
-    // GT Portal (local CTNH build)
-    modImplementation("extra-mods:gtportal-ctnh-1.1.7:1.1.7")
+    // GT Portal
+    modImplementation("curse.maven:gt-portal-1459620:7884803")
 
     // GregTech Construct (local patched build)
     modImplementation("extra-mods:GregTech-Construct-3.11.2.180:3.11.2.180")


### PR DESCRIPTION
本地构建坐标 \xtra-mods:gtportal-ctnh-1.1.7:1.1.7\ 没有随仓库提供，导致 CTNH-Core 编译时无法解析依赖。

改为直接使用 CurseForge 上的 \gt-portal\（\curse.maven:gt-portal-1459620:7884803\），保留 jarJar 嵌入和运行时依赖，且不依赖 CTNH-Modules 父仓库尚未同步的版本目录别名。

已本地验证：\:modules:CTNH-Core:compileJava\、\:modules:CTNH-Core:build\、\spotlessApply\ 均通过。